### PR TITLE
ci: add report card (A+) and mutation testing gates

### DIFF
--- a/.github/workflows/goreportcard.yml
+++ b/.github/workflows/goreportcard.yml
@@ -1,0 +1,112 @@
+name: Go Report Card
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  report-card:
+    name: Enforce A+ grade
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install tools
+        run: |
+          go install github.com/fzipp/gocyclo/cmd/gocyclo@latest
+          go install github.com/gordonklaus/ineffassign@latest
+
+      - name: Score (must be > 90% for A+)
+        run: |
+          python3 - <<'EOF'
+          import subprocess, sys, os
+
+          def lines(cmd):
+              r = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+              return [l for l in (r.stdout + r.stderr).splitlines() if l]
+
+          # Replicate goreportcard's GoFiles() exclusions
+          files = lines(
+              "find . -name '*.go'"
+              " -not -path './vendor/*'"
+              " -not -path './Godeps/*'"
+              " -not -path './third_party/*'"
+              " -not -path './testdata/*'"
+              " -not -name '*.pb.go'"
+              " -not -name '*.pb.gw.go'"
+              " -not -name '*.generated.go'"
+              " -not -name 'bindata.go'"
+              " -not -name '*_string.go'"
+          )
+          n = len(files)
+          farg = " ".join(files)
+
+          # gofmt -s: per-file pass rate (weight 0.30)
+          gofmt_fail = len(lines(f"gofmt -s -l {farg}"))
+          gofmt = (n - gofmt_fail) / n
+
+          # go vet: per-file pass rate (weight 0.30)
+          vet_r = subprocess.run("go vet ./...", shell=True, capture_output=True, text=True)
+          if vet_r.returncode == 0:
+              vet = 1.0
+          else:
+              vet_fail_files = set()
+              for line in (vet_r.stdout + vet_r.stderr).splitlines():
+                  if not line or line.startswith("#"):
+                      continue
+                  fname = line.split(":")[0].lstrip("./")
+                  if fname.endswith(".go"):
+                      vet_fail_files.add(fname)
+              vet = (n - len(vet_fail_files)) / n
+
+          # gocyclo --cyclo-over=15: per-file pass rate (weight 0.10)
+          over = {l.split()[-1].split(":")[0] for l in lines("gocyclo -over 15 .")}
+          cyclo = (n - len(over)) / n
+
+          # license: 1.0 if present, 0.0 if not (weight 0.05)
+          prefixes = {"license", "copying", "copyright", "licence", "unlicense", "copyleft"}
+          has_license = any(
+              any(f.lower().startswith(p) for p in prefixes)
+              for f in os.listdir(".")
+          )
+          license_score = 1.0 if has_license else 0.0
+
+          # ineffassign: auto-passes on repos > 100 files (weight 0.10)
+          if n > 100:
+              ineffassign = 1.0
+          else:
+              ia_lines = lines(f"ineffassign {farg}")
+              ia_fail = len({l.split(":")[0] for l in ia_lines if ":" in l})
+              ineffassign = (n - ia_fail) / n
+
+          # misspell weight is 0.0 — shown on report card but never affects grade
+
+          checks = [
+              ("gofmt",       gofmt,         0.30),
+              ("go vet",      vet,           0.30),
+              ("gocyclo",     cyclo,         0.10),
+              ("license",     license_score, 0.05),
+              ("ineffassign", ineffassign,   0.10),
+          ]
+          total_weight = sum(w for _, _, w in checks)
+          score = sum(r * w for _, r, w in checks) / total_weight
+
+          for name, rate, w in checks:
+              print(f"  {name:<14} {rate:6.1%}  weight={w:.2f}")
+          print(f"  {'score':<14} {score:6.1%}")
+          grade = "A+" if score > 0.90 else "A" if score > 0.80 else "B" if score > 0.70 else "<B"
+          print(f"  {'grade':<14} {grade}")
+
+          if score <= 0.90:
+              print("FAIL: score must be > 90% for A+")
+              sys.exit(1)
+          print("PASS: A+")
+          EOF

--- a/.github/workflows/mutation.yml
+++ b/.github/workflows/mutation.yml
@@ -1,0 +1,38 @@
+name: Mutation Testing
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  mutation:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Install mutago
+        run: go install github.com/quality-gates/mutago/v2/cmd/mutago@latest
+
+      - name: Run mutation testing
+        # --coverage profiles the package first; mutations on uncovered lines are
+        # marked "not covered" and skipped rather than running the test suite against them.
+        # --min-covered-msi enforces the quality gate on covered-code MSI.
+        # --logger-github emits each escaped mutant as an inline PR annotation.
+        # --exec-timeout caps each individual mutation run to 30 s.
+        run: |
+          mutago \
+            --coverage \
+            --min-covered-msi 95 \
+            --logger-github \
+            --exec-timeout 30 \
+            ./...

--- a/gleam.go
+++ b/gleam.go
@@ -371,8 +371,22 @@ func encodeCacheItem(item CacheItem) ([]byte, error) {
 	return []byte(encoded), nil
 }
 
+// readSized reads a uint32 length prefix then exactly that many bytes from r.
+// It collapses the repeated binary.Read/buf.Read pairs in decodeCacheItem,
+// keeping cyclomatic complexity under the gocyclo threshold of 15.
+func readSized(r *bytes.Reader) ([]byte, error) {
+	var n uint32
+	if err := binary.Read(r, binary.LittleEndian, &n); err != nil {
+		return nil, err
+	}
+	b := make([]byte, n)
+	if _, err := r.Read(b); err != nil {
+		return nil, err
+	}
+	return b, nil
+}
+
 func decodeCacheItem(data []byte) (*CacheItem, error) {
-	// Decode the base64 input
 	decoded, err := base64.StdEncoding.DecodeString(string(data))
 	if err != nil {
 		return nil, err
@@ -381,13 +395,7 @@ func decodeCacheItem(data []byte) (*CacheItem, error) {
 	buf := bytes.NewReader(decoded)
 	item := &CacheItem{}
 
-	// Read content length and content
-	var contentLen uint32
-	if err := binary.Read(buf, binary.LittleEndian, &contentLen); err != nil {
-		return nil, err
-	}
-	item.content = make([]byte, contentLen)
-	if _, err := buf.Read(item.content); err != nil {
+	if item.content, err = readSized(buf); err != nil {
 		return nil, err
 	}
 
@@ -397,53 +405,35 @@ func decodeCacheItem(data []byte) (*CacheItem, error) {
 	}
 	item.status = int(status)
 
-	// Read the headers
 	var headerLen uint32
 	if err := binary.Read(buf, binary.LittleEndian, &headerLen); err != nil {
 		return nil, err
 	}
 	item.header = make(http.Header, headerLen)
 	for i := uint32(0); i < headerLen; i++ {
-		// Read the header key
-		var keyLen uint32
-		if err := binary.Read(buf, binary.LittleEndian, &keyLen); err != nil {
-			return nil, err
-		}
-		key := make([]byte, keyLen)
-		if _, err := buf.Read(key); err != nil {
+		key, err := readSized(buf)
+		if err != nil {
 			return nil, err
 		}
 
-		// Read the number of values for this header key
 		var valuesLen uint32
 		if err := binary.Read(buf, binary.LittleEndian, &valuesLen); err != nil {
 			return nil, err
 		}
 		values := make([]string, valuesLen)
 		for j := uint32(0); j < valuesLen; j++ {
-			// Read each value
-			var valueLen uint32
-			if err := binary.Read(buf, binary.LittleEndian, &valueLen); err != nil {
-				return nil, err
-			}
-			value := make([]byte, valueLen)
-			if _, err := buf.Read(value); err != nil {
+			value, err := readSized(buf)
+			if err != nil {
 				return nil, err
 			}
 			values[j] = string(value)
 		}
 
-		// Store the key-value pair in the header map
 		item.header[string(key)] = values
 	}
 
-	// Read expiration time
-	var expirationLen uint32
-	if err := binary.Read(buf, binary.LittleEndian, &expirationLen); err != nil {
-		return nil, err
-	}
-	expirationBytes := make([]byte, expirationLen)
-	if _, err := buf.Read(expirationBytes); err != nil {
+	expirationBytes, err := readSized(buf)
+	if err != nil {
 		return nil, err
 	}
 	if err := item.expiration.UnmarshalBinary(expirationBytes); err != nil {


### PR DESCRIPTION
Two new CI workflows modelled directly on [quality-gates/mutago's own pipeline](https://github.com/quality-gates/mutago/tree/main/.github/workflows).

## `goreportcard.yml` — enforce A+ grade

Replicates goreportcard.io's scoring formula locally so no external API call is needed. Checks:

| check | weight |
|---|---|
| `gofmt -s` | 0.30 |
| `go vet` | 0.30 |
| `gocyclo -over 15` | 0.10 |
| license file present | 0.05 |
| `ineffassign` | 0.10 |

Fails if weighted score ≤ 90% (the A+ boundary). Current score: **100%**.

## `mutation.yml` — covered-MSI gate

```
go install github.com/quality-gates/mutago/v2/cmd/mutago@latest
mutago --coverage --min-covered-msi 95 --logger-github --exec-timeout 30 ./...
```

- `--coverage`: profiles the package first; mutants on uncovered lines are marked *not covered* and skipped rather than running the test suite against them.
- `--min-covered-msi 95`: quality gate. Current score is **97.96%** (96/98 covered mutants killed), giving ~3% headroom.
- `--logger-github`: each escaped mutant appears as an inline annotation on the PR diff.
- Job timeout: 30 min.

## `gleam.go` — extract `readSized` helper

`gocyclo` reported `decodeCacheItem` at complexity **16** (threshold 15), which would have failed the report card. Four repeated `binary.Read` + `buf.Read` pairs are collapsed into calls to a new `readSized` helper, dropping complexity to **12**. All existing tests continue to pass.