### PR TITLE
Fix cache status code validation in encodeCacheItem

### DIFF
--- a/gleam.go
+++ b/gleam.go
@@ -324,6 +324,9 @@ func encodeCacheItem(item CacheItem) ([]byte, error) {
 	}
 
 	status := uint32(item.status)
+	if status < 100 || status > 999 {
+		return nil, fmt.Errorf("cache item: invalid status code %d", status)
+	}
 	if err := binary.Write(&buf, binary.LittleEndian, status); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
encodeCacheItem allows encoding of invalid HTTP status codes which are then rejected by decodeCacheItem, breaking cache integrity. This ensures bounds checking matches decode.