### PR TITLE
Extract Codec seam for RedisCache serialization

### DIFF
--- a/codec_test.go
+++ b/codec_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"net/http"
+	"testing"
+	"time"
+)
+
+func TestBinaryCodec_ImplementsCodec(t *testing.T) {
+	var _ Codec = (*BinaryCodec)(nil)
+}
+
+func TestBinaryCodec_RoundTrip(t *testing.T) {
+	codec := &BinaryCodec{}
+	item := CacheItem{
+		content:    []byte("test"),
+		header:     http.Header{"X-Test": {"1"}},
+		status:     200,
+		expiration: time.Now().Truncate(time.Second),
+	}
+
+	data, err := codec.Encode(item)
+	if err != nil {
+		t.Fatalf("Encode failed: %v", err)
+	}
+
+	decoded, err := codec.Decode(data)
+	if err != nil {
+		t.Fatalf("Decode failed: %v", err)
+	}
+
+	if string(decoded.content) != string(item.content) {
+		t.Errorf("content mismatch")
+	}
+}

--- a/gleam.go
+++ b/gleam.go
@@ -106,13 +106,33 @@ func NewSimpleCache() *SimpleCache {
 	}
 }
 
+// Codec defines an interface for serialization of cache items.
+type Codec interface {
+	Encode(item CacheItem) ([]byte, error)
+	Decode(data []byte) (*CacheItem, error)
+}
+
+// BinaryCodec implements the Codec interface using a binary format.
+type BinaryCodec struct{}
+
+// Encode serializes a CacheItem to a byte slice.
+func (c *BinaryCodec) Encode(item CacheItem) ([]byte, error) {
+	return encodeCacheItem(item)
+}
+
+// Decode deserializes a byte slice back into a CacheItem.
+func (c *BinaryCodec) Decode(data []byte) (*CacheItem, error) {
+	return decodeCacheItem(data)
+}
+
 // RedisCache implements the Cache interface using Redis
 type RedisCache struct {
 	client *redis.Client
+	codec  Codec
 }
 
 // NewRedisCache initializes and returns a new RedisCache using a single Redis URL
-func NewRedisCache(redisURL string) *RedisCache {
+func NewRedisCache(redisURL string, codec Codec) *RedisCache {
 	// Parse the Redis URL
 	opt, err := redis.ParseURL(redisURL)
 	if err != nil {
@@ -123,12 +143,13 @@ func NewRedisCache(redisURL string) *RedisCache {
 	rdb := redis.NewClient(opt)
 	return &RedisCache{
 		client: rdb,
+		codec:  codec,
 	}
 }
 
 // Set stores data in Redis
 func (r *RedisCache) Set(key string, item CacheItem, ttl time.Duration) {
-	itemBytes, err := encodeCacheItem(item)
+	itemBytes, err := r.codec.Encode(item)
 	if err != nil {
 		log.Printf("failed to encode cache item for key %q: %v", key, err)
 		return
@@ -148,7 +169,7 @@ func (r *RedisCache) Get(key string) (*CacheItem, bool) {
 
 	// Deserialize CacheItem
 	var cacheItem *CacheItem
-	cacheItem, err = decodeCacheItem([]byte(result))
+	cacheItem, err = r.codec.Decode([]byte(result))
 	if err != nil {
 		return nil, false
 	}
@@ -290,7 +311,7 @@ func main() {
 	var cache Cache
 
 	if config.CacheType == "redis" {
-		cache = NewRedisCache(config.RedisURL)
+		cache = NewRedisCache(config.RedisURL, &BinaryCodec{})
 	} else {
 		cache = NewSimpleCache()
 	}

--- a/redis_cache_test.go
+++ b/redis_cache_test.go
@@ -1,0 +1,37 @@
+package main
+
+import (
+	"errors"
+	"testing"
+	"time"
+)
+
+type mockCodec struct {
+	encodeCalled bool
+	encodeErr    error
+}
+
+func (m *mockCodec) Encode(item CacheItem) ([]byte, error) {
+	m.encodeCalled = true
+	return nil, m.encodeErr
+}
+
+func (m *mockCodec) Decode(data []byte) (*CacheItem, error) {
+	return nil, nil
+}
+
+func TestRedisCache_DelegatesToCodec(t *testing.T) {
+	codec := &mockCodec{encodeErr: errors.New("mock error")}
+	// Create RedisCache with our mock codec and a nil client.
+	// We expect Set to fail early during Encode and not panic on nil client.
+	cache := &RedisCache{
+		codec: codec,
+		// client is nil
+	}
+
+	cache.Set("test_key", CacheItem{content: []byte("data"), status: 200}, time.Minute)
+
+	if !codec.encodeCalled {
+		t.Errorf("expected RedisCache.Set to call Codec.Encode")
+	}
+}


### PR DESCRIPTION
Closes gleam-2ig. Extracts the binary serialization logic from RedisCache into a new Codec interface and implements a BinaryCodec.