### PR TITLE
ci: codify golangci-lint workaround in github actions

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,6 +14,16 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v3
 
+    - name: Setup Go
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: go.mod
+
+    - name: Run linter
+      run: |
+        ./scripts/install-golangci-lint.sh
+        GOTOOLCHAIN=go1.24.10 ./bin/golangci-lint run --build-tags=gms_pure_go ./...
+
     - name: Build Docker image
       run: docker build -t jonbaldie/gleam .
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ report.json
 
 # Beads / Dolt files (added by bd init)
 .beads/proxieddb/
+/bin/


### PR DESCRIPTION
This adds the exact golangci-lint execution instructions from the README into the build-and-test workflow to ensure they are continuously validated.
